### PR TITLE
update manifest to 1.0.4 to fix response.json errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "wikidata-importer",
 	"name": "Wikidata Importer",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"minAppVersion": "0.15.0",
 	"description": "Import data from Wikidata into your vault.",
 	"author": "Sam Rose",


### PR DESCRIPTION
There is a bug in the way the current version of obsidian works with the 1.0.3 version of this plugin where the response object from requestUrl is trying to be called a function which does not work.  It appears that this plugin already has a fix that is tagged and released as 1.0.4 but I think the manifest was not updated, and therefore the catalog in obsidian is still pulling the old tag.