### PR TITLE
internalLinkPrefix formattable to include the Entity-ID in the Link-Paths and Entity.md Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Intellij
 *.iml
 .idea
+.vs
 
 # npm
 node_modules

--- a/main.ts
+++ b/main.ts
@@ -22,7 +22,7 @@ interface WikidataImporterSettings {
 
 const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	entityIdKey: "wikidata entity id",
-	internalLinkPrefix: "db/",
+	internalLinkPrefix: "db/${label}",
 	ignoreCategories: true,
 	ignoreWikipediaPages: true,
 	ignoreIDs: true,
@@ -85,8 +85,7 @@ class WikidataEntitySuggestModal extends SuggestModal<Entity> {
 		let loading = new Notice(`Importing entity ${item.id}...`);
 
 		try {
-			let prefix = this.plugin.settings.internalLinkPrefix;
-			let name = `${prefix}${item.label}.md`;
+			let name = Entity.buildLink(this.plugin.settings.internalLinkPrefix + `.md`, item.label, item.id.substring(1));
 			let file = this.app.vault.getAbstractFileByPath(name);
 			if (!(file instanceof TFile)) {
 				file = await this.app.vault.create(name, "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
+	"version": "1.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-sample-plugin",
-			"version": "1.0.0",
+			"version": "1.0.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -69,6 +69,26 @@ export class Entity {
 		return json.search.map(Entity.fromJson);
 	}
 
+	static buildLink(link : string, label : string, id : string) : string {
+		const subst = '_';
+		label = label
+			.replace(/\\/g, subst)
+			.replace(/\*/g, subst)
+			.replace(/\//g, subst)
+			.replace(/\:/g, subst)
+			.replace(/\#/g, subst)
+			.replace(/\?/g, subst)
+			.replace(/\</g, subst)
+			.replace(/\>/g, subst)
+			.replace(/\ /g, subst)
+			.replace(/\"/g, subst);
+
+		link = link
+			.replace(/\$\{label\}/g, label)
+			.replace(/\$\{id\}/g, id);
+		return link;
+	}
+
 	// TODO: incorporate https://query.wikidata.org/#SELECT%20%3FwdLabel%20%3Fps_Label%20%3FwdpqLabel%20%3Fpq_Label%20%7B%0A%20%20VALUES%20%28%3Fcompany%29%20%7B%28wd%3AQ5284%29%7D%0A%20%20%0A%20%20%3Fcompany%20%3Fp%20%3Fstatement%20.%0A%20%20%3Fstatement%20%3Fps%20%3Fps_%20.%0A%20%20%0A%20%20%3Fwd%20wikibase%3Aclaim%20%3Fp.%0A%20%20%3Fwd%20wikibase%3AstatementProperty%20%3Fps.%0A%20%20%0A%20%20OPTIONAL%20%7B%0A%20%20%3Fstatement%20%3Fpq%20%3Fpq_%20.%0A%20%20%3Fwdpq%20wikibase%3Aqualifier%20%3Fpq%20.%0A%20%20%7D%0A%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22%20%7D%0A%7D%20ORDER%20BY%20%3Fwd%20%3Fstatement%20%3Fps_
 	async getProperties(opts: GetPropertiesOptions): Promise<Properties> {
 		let query = `
@@ -153,7 +173,11 @@ export class Entity {
 			} else if (isString(type)) {
 				toAdd = value;
 			} else if (value.match(/Q\d+$/) && valueLabel) {
-				toAdd = `[[${opts.internalLinkPrefix}${valueLabel}]]`;
+				let id = value.match(/\d+$/);
+				console.log("found id: " + label);
+				id = id[0];
+				var label = Entity.buildLink(opts.internalLinkPrefix, valueLabel, id);
+				toAdd = `[[${label}]]`;
 			}
 
 			if (toAdd === null) {

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -69,19 +69,21 @@ export class Entity {
 		return json.search.map(Entity.fromJson);
 	}
 
+	static replaceCharacters(str : string, searchString : string, replaceString : string) {
+		let result = str;
+    
+		for (let i = 0; i < searchString.length; i++) {
+			const searchChar = searchString[i];
+			const replaceChar = replaceString[Math.min(i, replaceString.length - 1)];
+        
+			result = result.replace(new RegExp('\\' + searchChar, 'g'), replaceChar);
+		}
+    
+		return result;
+	}
+
 	static buildLink(link : string, label : string, id : string) : string {
-		const subst = '_';
-		label = label
-			.replace(/\\/g, subst)
-			.replace(/\*/g, subst)
-			.replace(/\//g, subst)
-			.replace(/\:/g, subst)
-			.replace(/\#/g, subst)
-			.replace(/\?/g, subst)
-			.replace(/\</g, subst)
-			.replace(/\>/g, subst)
-			.replace(/\ /g, subst)
-			.replace(/\"/g, subst);
+		label = Entity.replaceCharacters(label, '\*/:#?<> "', '_');
 
 		link = link
 			.replace(/\$\{label\}/g, label)


### PR DESCRIPTION
Hi, this small PR allows to disambiguate duplicate Labels by appending or prepending the WikiData Entity-ID. 
It replaces all occurrences of `${label}` and `${id}` with the corresponding Entity-label resp. Entity-ID . 

To emulate the current internalLinkPrefix Behavior, the Default must be changed from `db/` to `db/${label}`. 
For my purposes I changed it to `db/Q${id}`, so I get the WikiData IDs as File Names. 

Additionally it replaces all reserved URL Parameters by '_'. 
If you agree, I could add 2 more Configuration Strings to define a Search- and a Replace-String, 
to allow for configuring which Characters are replaced by what other Character. 
It would replace each Search-Character by the corresponding Replace-Character 
or nothing, when the Replace String is briefer than the Search-String, 
so the current Behavior could be emulated by these 2 Strings: 
- Search: `\*/:#?<> "`
- Replace: `__________`

If you don't want any replacements, just clear the Search String. 