### PR TITLE
Search Entity from note title if no entity id is set

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -134,8 +134,12 @@ export default class WikidataImporterPlugin extends Plugin {
 		let entityId = frontmatter[this.settings.entityIdKey];
 		if (!entityId || !entityId.startsWith("Q")) {
 			new Notice(
-				"To import Wikidata properties, you must define a Wikidata entity ID in the frontmatter"
+				`No Wikidata entity ID found in frontmatter key "${this.settings.entityIdKey}", searching for a Wikidata entity from the note title "${file.basename}..."`
 			);
+			const modal = new WikidataEntitySuggestModal(this);
+			modal.open();
+			modal.inputEl.value = file.basename;
+			modal.inputEl.dispatchEvent(new Event("input"));
 			return;
 		}
 

--- a/main.ts
+++ b/main.ts
@@ -134,7 +134,7 @@ export default class WikidataImporterPlugin extends Plugin {
 		let entityId = frontmatter[this.settings.entityIdKey];
 		if (!entityId || !entityId.startsWith("Q")) {
 			new Notice(
-				`No Wikidata entity ID found in frontmatter key "${this.settings.entityIdKey}", searching for a Wikidata entity from the note title "${file.basename}..."`
+				`No Wikidata entity ID found in frontmatter key "${this.settings.entityIdKey}", searching for a Wikidata entity from the file name "${file.basename}"...`
 			);
 			const modal = new WikidataEntitySuggestModal(this);
 			modal.open();


### PR DESCRIPTION
When there is no `wikidata entry id` YAML frontmatter property, the plugin will launch a search in the modal for entities matching the file name. If the user finds a satisfying entity, a click will create the Wikidata entity file.

## Note

When using `wikidata entry id`, the plugin adds the properties to the current file containing the id. With my update, it runs a search and allows the user to import the Wikidata Entity using the other command's behavior, creating the file in `db/${label}`. Thus, the current file is _not_ modified. This may seem weird at first sight, but as I see it this behavior is not much of an issue, for the following reasons. 

First, I like to keep all Wikidata items nicely stored in the `db` folder to be able to keep the internal links clean and working. I can then click on an item in one of the Wikidata properties, wgucg creates the file is missing, them update it as required, including adding Wikidata (which is made easier with this PR). This way, the behavior is "transparent", as the active file is the same as the "Wikidata file".

Then, if one takes the trouble to manually insert a YAML frontmatter property into a file, she would naturally expect the file to be updated, not a new one to be created. Then, the actual behavior with the `wikidata entity id` (update the current file) is preserved.

Possible workarounds if another behavior is preferred would be to either : 
- split the command to another dedicated command to do just that, with a "better" more explicit name ;
- update the modal so that it can either create a new file or update an existing file, and use it accordingly in the various use cases.

## Demo


https://github.com/samwho/obsidian-wikidata-importer/assets/39006/359c1a5f-d7eb-4879-96df-8e1fbf389e84


Closes #1 