### PR TITLE
Search a Wikidata Entity from text selection

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import {
 	App,
+	MarkdownView,
 	Notice,
 	Plugin,
 	PluginSettingTab,
@@ -153,6 +154,49 @@ export default class WikidataImporterPlugin extends Plugin {
 		}
 	}
 
+	async importEntityFromHighlightedText() {
+		const file = this.app.workspace.getActiveFile();
+		if (!file) {
+			new Notice("No active file");
+			return;
+		}
+
+		let selection;
+		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+		if (view) {
+			const view_mode = view.getMode();
+			switch (view_mode) {
+				case "preview":
+					// The plugin does not support importing entities from the preview mode yet.
+					break;
+				case "source":
+					if ("editor" in view) {
+						selection = view.editor.getSelection();
+					}
+					break;
+				default:
+					break;
+			}
+		}
+		if (!selection) {
+			new Notice("No text selected");
+			return;
+		}
+		const loading = new Notice("Loading entity from highlighted text...");
+		try {
+			// Search a Wikidata entity from the highlighted text, using the modal
+			const modal = new WikidataEntitySuggestModal(this);
+			modal.open();
+			modal.inputEl.value = selection;
+			modal.inputEl.dispatchEvent(new Event("input"));
+		} catch (e) {
+			new Notice(`Error importing entity from highlighted text: ${e}`);
+			return;
+		} finally {
+			loading.hide();
+		}
+	}
+
 	async onload() {
 		await this.loadSettings();
 
@@ -168,6 +212,12 @@ export default class WikidataImporterPlugin extends Plugin {
 			callback: () => {
 				new WikidataEntitySuggestModal(this).open();
 			},
+		});
+
+		this.addCommand({
+			id: "import-entity-from-highlighted-text",
+			name: "Import entity from highlighted text",
+			editorCallback: this.importEntityFromHighlightedText.bind(this),
 		});
 
 		this.addSettingTab(new WikidataImporterSettingsTab(this.app, this));


### PR DESCRIPTION
This allows to search a Wikidata Entity from the editor's search selection.
Using the [Commander Plugin](https://github.com/phibr0/obsidian-commander), you can add the command to the right-click context menu of Obsidian.

## Note
The code is largely taken from this Obsidian forum post : https://forum.obsidian.md/t/get-current-text-selection/23436/3 .
It does not work in `preview mode` yet. 

## Demo

https://github.com/samwho/obsidian-wikidata-importer/assets/39006/e0b79990-6990-433d-9b2e-a6f69da976df

