### PR TITLE
Filter properties

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -55,11 +55,14 @@ async function syncEntityToFile(
 
 	for (const [key, value] of Object.entries(properties)) {
 		if (
+			// If the whitelist is defined, only import properties that are in the whitelist
+			// If the blacklist is defined, do not import properties that are in the blacklist
 			(plugin.settings.whitelist?.length &&
-				!plugin.settings.whitelist?.includes(key)) ||
-			plugin.settings.blacklist?.includes(key)
+				!plugin.settings.whitelist.includes(key)) ||
+			(plugin.settings.blacklist?.length &&
+				plugin.settings.blacklist.includes(key))
 		) {
-			console.log(`Skipping property ${key}`);
+			console.log(`Wikidata: skipping property ${key}`);
 			continue;
 		} else {
 			filteredProperties.push(key);
@@ -328,7 +331,10 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 					.setPlaceholder("label1\nlabel2\n...")
 					.setValue(this.plugin.settings.blacklist?.join("\n"))
 					.onChange(async (value) => {
-						this.plugin.settings.blacklist = value.split("\n");
+						this.plugin.settings.blacklist = value
+							.trim()
+							.split("\n")
+							.filter(Boolean);
 						await this.plugin.saveSettings();
 					})
 			);
@@ -343,7 +349,10 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 					.setPlaceholder("label1\nlabel2\n...")
 					.setValue(this.plugin.settings.whitelist?.join("\n"))
 					.onChange(async (value) => {
-						this.plugin.settings.whitelist = value.split("\n");
+						this.plugin.settings.whitelist = value
+							.trim()
+							.split("\n")
+							.filter(Boolean);
 						await this.plugin.saveSettings();
 					})
 			);

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,8 @@ const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	ignoreIDs: true,
 	ignorePropertiesWithTimeRanges: true,
 	overwriteExistingProperties: false,
+	blacklist: [],
+	whitelist: [],
 };
 
 async function syncEntityToFile(


### PR DESCRIPTION
This update allows filtering properties to import with two antagonist filtering strategies:
- whitelist : only retain matching properties;
- blacklist : exclude those properties from this list, and exclude everything else.

## Demo


https://github.com/samwho/obsidian-wikidata-importer/assets/39006/65327045-65ab-4ca9-a68a-efb842730628

Closes #7 