### PR TITLE
replace non-Letter characters in Property-Names

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -14,6 +14,7 @@ import { Entity } from "./src/wikidata";
 interface WikidataImporterSettings {
 	entityIdKey: string;
 	internalLinkPrefix: string;
+	spaceReplacement: string;
 	ignoreCategories: boolean;
 	ignoreWikipediaPages: boolean;
 	ignoreIDs: boolean;
@@ -27,6 +28,7 @@ interface WikidataImporterSettings {
 const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	entityIdKey: "wikidata entity id",
 	internalLinkPrefix: "db/${label}",
+	spaceReplacement: "_",
 	ignoreCategories: true,
 	ignoreWikipediaPages: true,
 	ignoreIDs: true,
@@ -55,6 +57,7 @@ async function syncEntityToFile(
 		ignorePropertiesWithTimeRanges:
 			plugin.settings.ignorePropertiesWithTimeRanges,
 		internalLinkPrefix: plugin.settings.internalLinkPrefix,
+		spaceReplacement: plugin.settings.spaceReplacement,
 	});
 
 	const filteredProperties: string[] = [];
@@ -313,6 +316,21 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+		.setName("Replace-String for non-Letter characters in Properties")
+		.setDesc(
+			"Clear this to keep all non-Letter characters in Wikidata property names and leave them unchanged"
+		)
+		.addText((text) =>
+			text
+				.setPlaceholder(DEFAULT_SETTINGS.spaceReplacement)
+				.setValue(this.plugin.settings.spaceReplacement)
+				.onChange(async (value) => {
+					this.plugin.settings.spaceReplacement = value;
+					await this.plugin.saveSettings();
+				})
+		);
 
 		new Setting(containerEl)
 			.setName("Internal link prefix")

--- a/main.ts
+++ b/main.ts
@@ -318,7 +318,7 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-		.setName("Replace-String for non-Letter characters in Properties")
+		.setName("Non-letter character replacement string (properties only)")
 		.setDesc(
 			"Clear this to keep all non-Letter characters in Wikidata property names and leave them unchanged"
 		)

--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ interface WikidataImporterSettings {
 const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	entityIdKey: "wikidata entity id",
 	internalLinkPrefix: "db/${label}",
-	spaceReplacement: "_",
+	spaceReplacement: "",
 	ignoreCategories: true,
 	ignoreWikipediaPages: true,
 	ignoreIDs: true,

--- a/main.ts
+++ b/main.ts
@@ -320,7 +320,7 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 		.setName("Non-letter character replacement string (properties only)")
 		.setDesc(
-			"Clear this to keep all non-Letter characters in Wikidata property names and leave them unchanged"
+			"If this is set, non-letter characters in property names will be replaced with this value. Use this to replace spaces with, e.g. the underscore character such that you don't have to quote your property names when searching your vault."
 		)
 		.addText((text) =>
 			text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.0.6",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-sample-plugin",
-			"version": "1.0.6",
+			"version": "1.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
-				"esbuild": "0.17.3",
+				"esbuild": "^0.17.3",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "^4.7.4"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -999,6 +999,7 @@
 			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2132,6 +2133,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,17 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"esbuild": "0.17.3",
+		"esbuild": "^0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
-	}
+		"typescript": "^4.7.4"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/SpocWeb/obsidian-wikidata-importer.git"
+	},
+	"bugs": {
+		"url": "https://github.com/SpocWeb/obsidian-wikidata-importer/issues"
+	},
+	"homepage": "https://github.com/SpocWeb/obsidian-wikidata-importer#readme"
 }

--- a/package.json
+++ b/package.json
@@ -16,17 +16,9 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"esbuild": "^0.17.3",
+		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "^4.7.4"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/SpocWeb/obsidian-wikidata-importer.git"
-	},
-	"bugs": {
-		"url": "https://github.com/SpocWeb/obsidian-wikidata-importer/issues"
-	},
-	"homepage": "https://github.com/SpocWeb/obsidian-wikidata-importer#readme"
+		"typescript": "4.7.4"
+	}
 }

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -174,8 +174,8 @@ export class Entity {
 				return;
 			}
 
-			if (opts.spaceReplacement && opts.spaceReplacement && opts.spaceReplacement != " ") {
-				key = key.replace(" ", opts.spaceReplacement);
+			if (opts.spaceReplacement && opts.spaceReplacement.length > 0) {
+				key = key.replace(/[^\p{L}]/gu, opts.spaceReplacement);
 			}
 
 			let toAdd: Value | null = valueLabel;

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -175,7 +175,7 @@ export class Entity {
 			}
 
 			if (opts.spaceReplacement && opts.spaceReplacement.length > 0) {
-				key = key.replace(/[^\p{L}]/gu, opts.spaceReplacement);
+				key = key.replace(/[^\p{L}]+/gu, opts.spaceReplacement);
 			}
 
 			let toAdd: Value | null = valueLabel;

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -15,6 +15,7 @@ export interface GetPropertiesOptions {
 	ignoreIDs: boolean;
 	ignorePropertiesWithTimeRanges: boolean;
 	internalLinkPrefix: string;
+	spaceReplacement: string;
 }
 
 export interface SearchOptions {
@@ -143,7 +144,7 @@ export class Entity {
 		const ret: Properties = {};
 
 		results.forEach((r: any) => {
-			const key: string = r.propertyLabel.value;
+			let key: string = r.propertyLabel.value;
 			const value: string = r.value.value;
 			const normalizedValue: string | null = r.normalizedValue
 				? r.normalizedValue.value
@@ -171,6 +172,10 @@ export class Entity {
 
 			if (opts.ignoreIDs && valueLabel && key.match(/\bID\b/)) {
 				return;
+			}
+
+			if (opts.spaceReplacement && opts.spaceReplacement && opts.spaceReplacement != " ") {
+				key = key.replace(" ", opts.spaceReplacement);
 			}
 
 			let toAdd: Value | null = valueLabel;

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -175,7 +175,7 @@ export class Entity {
 			}
 
 			if (opts.spaceReplacement && opts.spaceReplacement.length > 0) {
-				key = key.replace(/[^\p{L}]+/gu, opts.spaceReplacement);
+				key = key.replace(/[^\d\p{L}]+/gu, opts.spaceReplacement);
 			}
 
 			let toAdd: Value | null = valueLabel;


### PR DESCRIPTION
WikiData Properties often contain Spaces and sometimes also other non-Letter Characters like Parentheses, Commas etc. 
Such Properties are harder to use e.g. in Dataview Expressions, because they must either be quoted or normalized 
(converted to lower-case and replacing any non-Letter Character with a dash) 

This PR adds an optional, configurable replace-String for sequences of non-letter Characters in WikiData Property-Names. 
The Default Replacement is an underscore, so that e.g. 
- for `Dewey Decimal Classification: "546.526"` 
- you can write `this.Dewey_Decimal_Classification` 
- instead of `=this["Dewey Decimal Classification"]`

This also makes it possible to generically map the FrontMatter to Properties in programming-Languages by Name, 
because most Languages allow for Letters and Underscore in Property- or Field-Names. 

If you want to keep the original Names as before, just clear the replace-String in the configuration. 
I can change the Default from "_" to "" if desired, so that the Plugin is backward compatible,

If desired, I can also make the regular Expression configurable. 
Currently it is `/[^\d\p{L}]+/gu` which matches multiple, consecutive non-Unicode-Letters or digits, 
replacing them with a single Underscore. 
I hope you find this modification useful, 

I could also publish some C# Code to migrate existing FrontMatter YAML to these friendly Property Names. 
