### PR TITLE
Bugfix: Emit Notice if entity search fails

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import {
 	PluginSettingTab,
 	Setting,
 	SuggestModal,
+	EntitySearchResult,
 	TFile,
 } from "obsidian";
 
@@ -110,6 +111,11 @@ class WikidataEntitySuggestModal extends SuggestModal<Entity> {
 	getSuggestions(query: string): Promise<Entity[]> {
 		return Entity.search(query, {
 			language: this.plugin.settings.language,
+		}).then((result: EntitySearchResult) => {
+			if (result.error) {
+				new Notice(`Error when searching for entities: ${result.error}`);
+			}
+			return result.entities;
 		});
 	}
 

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -50,8 +50,8 @@ function isString(type: string | null): boolean {
 
 function urlForSearch(query: string, opts: SearchOptions): string {
 	return "https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&type=item&limit=10"
+	+ `&language=${opts.language}&uselang=${opts.language}`
 	+ "&search=" + encodeURIComponent(query)
-	+ (opts.language ? `&language=${opts.language}&uselang=${opts.language}` : '');
 }
 
 function isInteger(type: string | null): boolean {

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -67,14 +67,19 @@ export class Entity {
 	static async search(query: string, opts: SearchOptions): Promise<Entity[]> {
 		if (!query || query.length === 0) return [];
 
-		const url =
-			`https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&language=${opts.language}&uselang=${opts.language}&type=item&limit=10&search=` +
-			encodeURIComponent(query);
+		const url = urlForSearch(query, opts);
 		console.log(url);
 		const response = await requestUrl(url);
 		const json: SearchResponse = response.json;
 		return json.search.map(Entity.fromJson);
 	}
+
+	static urlForSearch(query: string, opts: SearchOptions): string {
+		return "https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&type=item&limit=10"
+		     + "&search=" + encodeURIComponent(query)
+		     + (opts.language ? `&language=${opts.language}&uselang=${opts.language}` : '')
+	}
+
 
 	static replaceCharacters(
 		str: string,
@@ -97,7 +102,7 @@ export class Entity {
 		return result;
 	}
 
-	static buildLink(link: string, label: string, id: string): string {
+	static buildObsidianVaultInternalLink(link: string, label: string, id: string): string {
 		label = Entity.replaceCharacters(label, '*/:#?<>"', "_");
 		link = link.replace(/\$\{label\}/g, label).replace(/\$\{id\}/g, id);
 		return link;
@@ -192,7 +197,7 @@ export class Entity {
 				toAdd = value;
 			} else if (value.match(/Q\d+$/) && valueLabel) {
 				let id = value.match(/\d+$/)!;
-				var label = Entity.buildLink(
+				var label = Entity.buildObsidianVaultInternalLink(
 					opts.internalLinkPrefix,
 					valueLabel,
 					id[0]


### PR DESCRIPTION
This PR restructures the search to ensure that a suitable error message is returned if the search fails. 

I fell over this issue when I accidentally set the language setting to the empty string. This resulted in the search failing without an error message.