### PR TITLE
Use `mul` as default language in addition to `en`

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -36,7 +36,7 @@ const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	overwriteExistingProperties: false,
 	blockedProperties: [],
 	allowedProperties: [],
-	language: "en",
+	language: "mul,en",
 };
 
 async function syncEntityToFile(


### PR DESCRIPTION
Hi @samwho,

Thank you for your amazing plugin!
As `mul` is slowly gaining traction and replacing some other labels, I noticed that a lot of created items do not have a label anymore so it might be good to add it?

Best,

Adriano 