### PR TITLE
Also send queries to Qlever endpoint to obtain results for scholarly items

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,7 +9,7 @@ import {
 	TFile,
 } from "obsidian";
 
-import { Entity } from "./src/wikidata";
+import { Entity, EntityNotFoundError } from "./src/wikidata";
 
 interface WikidataImporterSettings {
 	entityIdKey: string;
@@ -27,6 +27,7 @@ interface WikidataImporterSettings {
 
 const DEFAULT_SETTINGS: WikidataImporterSettings = {
 	entityIdKey: "wikidata entity id",
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: this is intentional
 	internalLinkPrefix: "db/${label}",
 	spaceReplacement: "",
 	ignoreCategories: true,
@@ -116,6 +117,7 @@ class WikidataEntitySuggestModal extends SuggestModal<Entity> {
 
 		try {
 			if (this.plugin.settings.internalLinkPrefix === "db/") {
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: this is intentional
 				this.plugin.settings.internalLinkPrefix = "db/${label}";
 			}
 
@@ -150,7 +152,7 @@ class WikidataEntitySuggestModal extends SuggestModal<Entity> {
 }
 
 export default class WikidataImporterPlugin extends Plugin {
-	settings: WikidataImporterSettings;
+	settings!: WikidataImporterSettings;
 
 	async importProperties() {
 		const file = this.app.workspace.getActiveFile();
@@ -168,7 +170,7 @@ export default class WikidataImporterPlugin extends Plugin {
 				"https://www.wikidata.org/wiki/".length,
 			);
 		}
-		if (!entityId || !entityId.startsWith("Q")) {
+		if (!entityId?.startsWith("Q")) {
 			new Notice(
 				`No Wikidata entity ID found in frontmatter key "${this.settings.entityIdKey}", searching for a Wikidata entity from the file name "${file.basename}"...`,
 			);
@@ -184,6 +186,10 @@ export default class WikidataImporterPlugin extends Plugin {
 		try {
 			await syncEntityToFile(this, entity, file);
 		} catch (e) {
+			if (e instanceof EntityNotFoundError) {
+				new Notice(e.message);
+				return;
+			}
 			new Notice(
 				`Error importing properties for entity ${entity.id}: ${e}`,
 			);
@@ -325,7 +331,7 @@ class WikidataImporterSettingsTab extends PluginSettingTab {
 
 		const languageInput = languageSetting.controlEl.querySelector("input");
 		if (languageInput) {
-			languageInput.addEventListener("blur", (e) => {
+			languageInput.addEventListener("blur", () => {
 				const value = languageInput.value;
 				const error = languageValidationError(value);
 				if (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,23 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.1.1",
+	"version": "1.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-sample-plugin",
-			"version": "1.1.1",
+			"version": "1.1.3",
 			"license": "MIT",
 			"devDependencies": {
+				"@types/bun": "^1.3.13",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
-				"esbuild": "^0.17.3",
-				"obsidian": "latest",
+				"esbuild": "0.17.3",
+				"obsidian": "^1.12.3",
 				"tslib": "2.4.0",
-				"typescript": "^4.7.4"
+				"typescript": "^6.0.3"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -30,21 +31,27 @@
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
-			"integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
 			"dev": true,
-			"peer": true
-		},
-		"node_modules/@codemirror/view": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-			"integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
-			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@codemirror/state": "^6.1.4",
-				"style-mod": "^4.0.0",
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.38.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
 		},
@@ -496,6 +503,14 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -529,6 +544,16 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@types/bun": {
+			"version": "1.3.13",
+			"resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.13.tgz",
+			"integrity": "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bun-types": "1.3.13"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -875,6 +900,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bun-types": {
+			"version": "1.3.13",
+			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.13.tgz",
+			"integrity": "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -927,6 +962,14 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
+			"peer": true
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"dev": true,
+			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
@@ -1715,17 +1758,18 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.0.tgz",
-			"integrity": "sha512-fsZMPlxgflGSBSP6P4BjQi5+0MqZl3h6FEDEZ3CNnweNdDw0doyqN3FMO/PGWfuxPT77WicVwUxekuI3e6eCGg==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0"
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/once": {
@@ -2037,10 +2081,11 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
-			"integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/supports-color": {
@@ -2129,9 +2174,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2139,7 +2184,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uri-js": {
@@ -2157,6 +2202,7 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -5,20 +5,22 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
-		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"test": "bun test --preload ./src/test-setup.ts",
+		"build": "tsc -p tsconfig.build.json -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/bun": "^1.3.13",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
-		"obsidian": "latest",
+		"obsidian": "^1.12.3",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "^6.0.3"
 	}
 }

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,20 @@
+import { mock } from "bun:test";
+
+mock.module("obsidian", () => ({
+	requestUrl: async (
+		request: string | { url: string; headers?: Record<string, string> },
+	) => {
+		const url = typeof request === "string" ? request : request.url;
+		const headers =
+			typeof request === "string" ? undefined : request.headers;
+
+		const response = await fetch(url, { headers });
+		if (!response.ok) {
+			throw new Error(
+				`Request failed: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		return { json: await response.json() };
+	},
+}));

--- a/src/wikidata.test.ts
+++ b/src/wikidata.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { Entity, EntityNotFoundError } from "./wikidata";
+
+const DEFAULT_OPTIONS = {
+	language: "mul,en",
+	ignoreCategories: true,
+	ignoreWikipediaPages: true,
+	ignoreIDs: true,
+	ignorePropertiesWithTimeRanges: true,
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: intentional
+	internalLinkPrefix: "db/${label}",
+	spaceReplacement: "",
+};
+
+describe("Entity", () => {
+	test("searches Wikidata using configured languages", async () => {
+		const results = await Entity.search("Douglas Adams", {
+			language: "mul,en",
+		});
+
+		expect(results.some((entity) => entity.id === "Q42")).toBe(true);
+	});
+
+	test("resolves non-scholarly entity properties from live SPARQL services", async () => {
+		const properties =
+			await Entity.fromId("Q42").getProperties(DEFAULT_OPTIONS);
+
+		expect(properties["instance of"]).toContain("[[db/human]]");
+		expect(properties["date of birth"]).toContain("1952-03-11T00:00:00Z");
+		expect(properties.height).toContain(1.96);
+		expect(properties.DOI).toBeUndefined();
+	});
+
+	test("resolves scholarly entity properties from QLever", async () => {
+		const properties =
+			await Entity.fromId("Q4781761").getProperties(DEFAULT_OPTIONS);
+
+		expect(properties.DOI).toContain("10.1371/JOURNAL.PCBI.1002803");
+		expect(properties.title).toContain("Approximate Bayesian computation");
+		expect(properties["publication date"]).toContain(
+			"2013-01-01T00:00:00Z",
+		);
+		expect(properties["instance of"]).toContain("[[db/scholarly article]]");
+	});
+
+	test("throws when a Wikidata entity does not exist", async () => {
+		await expect(
+			Entity.fromId("Q34213821738927189371289371289").getProperties(
+				DEFAULT_OPTIONS,
+			),
+		).rejects.toThrow(EntityNotFoundError);
+	});
+
+	test("uses one preferred QLever label for multilingual property labels", async () => {
+		const properties = await Entity.fromId("Q42").getProperties({
+			...DEFAULT_OPTIONS,
+			language: "de,en",
+		});
+
+		expect(properties["Höhe"]).toContain(1.96);
+		expect(properties.height).toBeUndefined();
+	});
+});

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -22,16 +22,26 @@ export interface SearchOptions {
 	language: string;
 }
 
-// Wikidata SPARQL endpoint (main graph — excludes scholarly articles post-split)
+// ---------------------------------------------------------------------------
+// Endpoints
+// ---------------------------------------------------------------------------
+
+/** Wikidata Blazegraph endpoint. Post graph-split it no longer serves scholarly
+ *  articles (instance of Q13442814 and related types). */
 const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
 
-// QLever endpoint for Wikidata — full graph including scholarly articles
-// See: https://qlever.cs.uni-freiburg.de/wikidata
+/** QLever Wikidata mirror — full graph, including the scholarly-article split.
+ *  Does NOT support the wikibase:label SERVICE; uses rdfs:label instead.
+ *  Does NOT accept &format=json; format is negotiated via Accept header only. */
 const QLEVER_SPARQL = "https://qlever.cs.uni-freiburg.de/api/wikidata";
 
-// Standard Wikidata prefixes that query.wikidata.org injects automatically
-// but QLever requires explicitly.
-const WIKIDATA_PREFIXES = `
+// ---------------------------------------------------------------------------
+// Prefixes
+// ---------------------------------------------------------------------------
+
+/** Standard Wikidata SPARQL prefixes. Blazegraph injects these automatically;
+ *  QLever requires them to be declared explicitly. */
+const WIKIDATA_PREFIXES = `\
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
@@ -52,16 +62,40 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 `;
 
-// Scholarly article instance-of QIDs that live in the split-off graph
-const SCHOLARLY_QIDS = new Set([
-	"Q13442814", // scholarly article
-	"Q191067",   // article
-	"Q17928402", // scientific article
-	"Q18918145", // academic journal article
-	"Q23927052", // conference paper
-	"Q87715823", // preprint
-	"Q580922",   // review article
-]);
+// ---------------------------------------------------------------------------
+// Language helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the user-supplied language setting (e.g. "mul,en", "de", "zh,en") into
+ * an ordered list of real BCP-47 language tags, dropping the Wikidata-internal
+ * pseudo-code "mul" which is not valid inside SPARQL FILTER(LANG(…)) or the
+ * wikibase:label SERVICE.
+ *
+ * "en" is appended as a final fallback if not already present, so labels are
+ * never silently dropped when the preferred language is unavailable.
+ */
+function parseLangs(language: string): string[] {
+	const langs = language
+		.split(",")
+		.map((l) => l.trim().toLowerCase())
+		.filter((l) => l.length > 0 && l !== "mul");
+
+	if (!langs.includes("en")) langs.push("en");
+	return langs;
+}
+
+/**
+ * Build a SPARQL FILTER expression that accepts any of the given language tags.
+ *   FILTER(LANG(?x) = "de" || LANG(?x) = "en")
+ */
+function langFilter(variable: string, langs: string[]): string {
+	return langs.map((l) => `LANG(${variable}) = "${l}"`).join(" || ");
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
 
 function isString(type: string | null): boolean {
 	if (!type) return false;
@@ -86,50 +120,43 @@ function isDate(type: string | null): boolean {
 	return type === "http://www.w3.org/2001/XMLSchema#dateTime";
 }
 
+// ---------------------------------------------------------------------------
+// SPARQL runner
+// ---------------------------------------------------------------------------
+
 /**
- * Run a SPARQL SELECT query against the given endpoint and return raw bindings.
+ * Execute a SPARQL SELECT query and return the raw result bindings.
+ *
+ * @param endpoint  Full base URL of the SPARQL endpoint.
+ * @param query     Complete SPARQL query string (including PREFIX declarations
+ *                  when targeting QLever).
+ * @param qlever    When true, omits the Blazegraph-specific `&format=json`
+ *                  query parameter; format is negotiated via Accept header only.
  */
 async function runSparql(
 	endpoint: string,
 	query: string,
+	qlever = false,
 ): Promise<any[]> {
-	const url = `${endpoint}?query=${encodeURIComponent(query)}&format=json`;
+	const url = qlever
+		? `${endpoint}?query=${encodeURIComponent(query)}`
+		: `${endpoint}?query=${encodeURIComponent(query)}&format=json`;
+
 	try {
 		const response = await requestUrl({
 			url,
-			headers: {
-				// QLever requires an explicit Accept header for JSON
-				Accept: "application/sparql-results+json",
-			},
+			headers: { Accept: "application/sparql-results+json" },
 		});
 		return response.json?.results?.bindings ?? [];
 	} catch (e) {
-		console.warn(`SPARQL query failed for endpoint ${endpoint}:`, e);
+		console.warn(`[wikidata-importer] SPARQL query failed (${endpoint}):`, e);
 		return [];
 	}
 }
 
-/**
- * Check whether a Wikidata entity is a scholarly article by querying
- * QLever for its instance-of values.
- */
-async function isScholarlyEntity(id: string): Promise<boolean> {
-	const query = WIKIDATA_PREFIXES + `
-		SELECT ?type WHERE {
-			wd:${id} wdt:P31 ?type .
-		}
-		LIMIT 20
-	`;
-	const bindings = await runSparql(QLEVER_SPARQL, query);
-	for (const b of bindings) {
-		const typeUrl: string = b.type?.value ?? "";
-		const qid = typeUrl.match(/Q\d+$/)?.[0];
-		if (qid && SCHOLARLY_QIDS.has(`Q${qid.replace(/^Q/, "")}`)) {
-			return true;
-		}
-	}
-	return false;
-}
+// ---------------------------------------------------------------------------
+// Entity
+// ---------------------------------------------------------------------------
 
 export class Entity {
 	id: string;
@@ -161,15 +188,23 @@ export class Entity {
 
 	static async search(query: string, opts: SearchOptions): Promise<Entity[]> {
 		if (!query || query.length === 0) return [];
-		// support multiple comma-separated languages like "mul,en"
+
+		// Support comma-separated language list, including "mul" which the
+		// Wikidata action API does accept (unlike SPARQL FILTER).
 		const languages = opts.language
 			.split(",")
 			.map((l) => l.trim().toLowerCase())
 			.filter(Boolean);
+
 		const allResults = new Map<string, Entity>();
+
 		for (const lang of languages) {
-			const url = `https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&language=${lang}&uselang=${lang}&type=item&limit=10&search=${encodeURIComponent(query)}`;
-			console.log("Wikidata search:", url);
+			const url =
+				`https://www.wikidata.org/w/api.php` +
+				`?action=wbsearchentities&format=json` +
+				`&language=${lang}&uselang=${lang}` +
+				`&type=item&limit=10` +
+				`&search=${encodeURIComponent(query)}`;
 			try {
 				const response = await requestUrl(url);
 				const json: SearchResponse = response.json;
@@ -180,11 +215,12 @@ export class Entity {
 				}
 			} catch (e) {
 				console.warn(
-					`Wikidata search failed for language "${lang}":`,
+					`[wikidata-importer] Search failed for language "${lang}":`,
 					e,
 				);
 			}
 		}
+
 		return Array.from(allResults.values());
 	}
 
@@ -192,7 +228,7 @@ export class Entity {
 		str: string,
 		searchString: string,
 		replaceString: string,
-	) {
+	): string {
 		let result = str;
 		for (let i = 0; i < searchString.length; i++) {
 			const searchChar = searchString[i];
@@ -217,32 +253,56 @@ export class Entity {
 			.replace(/\$\{id\}/g, id);
 	}
 
+	// -------------------------------------------------------------------------
+	// Query builders
+	// -------------------------------------------------------------------------
+
 	/**
-	 * Build the SPARQL query body used by both endpoints.
-	 * `serviceBlock` is injected differently per endpoint since QLever
-	 * does not support the wikibase:label SERVICE — labels must be
-	 * fetched via rdfs:label directly.
+	 * Build the shared body of the properties SPARQL query.
+	 *
+	 * Two label strategies are supported:
+	 *
+	 * - Blazegraph (`useRdfsLabel = false`): uses the wikibase:label SERVICE
+	 *   which resolves labels server-side and handles language fallback
+	 *   automatically.
+	 *
+	 * - QLever (`useRdfsLabel = true`): the wikibase:label SERVICE is not
+	 *   supported, so labels are fetched via rdfs:label with an explicit
+	 *   FILTER over the user's preferred languages plus "en" as a fallback.
+	 *   "mul" is excluded because it is not a valid BCP-47 tag in FILTER(LANG()).
 	 */
 	private buildPropertiesQuery(
 		opts: GetPropertiesOptions,
 		useRdfsLabel: boolean,
 	): string {
+		const langs = parseLangs(opts.language);
+		// For the description OPTIONAL we use the first real language only
+		// (FILTER supports only one tag here in both endpoints).
+		const primaryLang = langs[0];
+
 		const labelFragment = useRdfsLabel
 			? `
-				OPTIONAL { ?property rdfs:label ?propertyLabel . FILTER(LANG(?propertyLabel) = "${opts.language}") }
-				OPTIONAL { ?value rdfs:label ?valueLabel . FILTER(LANG(?valueLabel) = "${opts.language}") }
-			`
+				OPTIONAL {
+					?property rdfs:label ?propertyLabel .
+					FILTER(${langFilter("?propertyLabel", langs)})
+				}
+				OPTIONAL {
+					?value rdfs:label ?valueLabel .
+					FILTER(${langFilter("?valueLabel", langs)})
+				}`
 			: `
 				SERVICE wikibase:label {
-					bd:serviceParam wikibase:language "[AUTO_LANGUAGE],${opts.language}" .
-				}
-			`;
+					bd:serviceParam wikibase:language "${langs.join(",")}" .
+				}`;
 
 		let query = `
 			SELECT ?propertyLabel ?value ?valueLabel ?valueType ?normalizedValue ?description WHERE {
 				wd:${this.id} ?propUrl ?value .
 				?property wikibase:directClaim ?propUrl .
-				OPTIONAL { wd:${this.id} schema:description ?description . FILTER (LANG(?description) = "${opts.language}") }
+				OPTIONAL {
+					wd:${this.id} schema:description ?description .
+					FILTER(LANG(?description) = "${primaryLang}")
+				}
 				OPTIONAL {
 					?statement psn:P31 ?normalizedValue .
 					?normalizedValue wikibase:quantityUnit ?unit .
@@ -258,15 +318,19 @@ export class Entity {
 			`;
 		}
 
-		query += labelFragment + `}`;
-
+		query += labelFragment + "\n\t\t}";
 		return query;
 	}
 
+	// -------------------------------------------------------------------------
+	// Binding parser
+	// -------------------------------------------------------------------------
+
 	/**
-	 * Parse raw SPARQL bindings into a Properties map, merging into `ret`.
-	 * Existing keys are extended rather than overwritten so results from
-	 * multiple endpoints can be combined cleanly.
+	 * Translate raw SPARQL result bindings into the Properties map, merging
+	 * into `ret`. Values that already exist (from a previous endpoint) are
+	 * deduplicated by string representation so that running both Blazegraph and
+	 * QLever never produces duplicate frontmatter entries.
 	 */
 	private parseBindings(
 		results: any[],
@@ -280,26 +344,21 @@ export class Entity {
 			const value: string = r.value?.value;
 			if (!value) continue;
 
-			const normalizedValue: string | null = r.normalizedValue
-				? r.normalizedValue.value
-				: null;
-			const type: string | null = r.valueType ? r.valueType.value : null;
-			const valueLabel: string | null = r.valueLabel
-				? r.valueLabel.value
-				: null;
+			const normalizedValue: string | null =
+				r.normalizedValue?.value ?? null;
+			const type: string | null = r.valueType?.value ?? null;
+			const valueLabel: string | null = r.valueLabel?.value ?? null;
 
 			if (
 				opts.ignoreCategories &&
-				valueLabel &&
-				valueLabel.startsWith("Category:")
+				valueLabel?.startsWith("Category:")
 			) {
 				continue;
 			}
 
 			if (
 				opts.ignoreWikipediaPages &&
-				valueLabel &&
-				valueLabel.startsWith("Wikipedia:")
+				valueLabel?.startsWith("Wikipedia:")
 			) {
 				continue;
 			}
@@ -308,7 +367,7 @@ export class Entity {
 				continue;
 			}
 
-			if (opts.spaceReplacement && opts.spaceReplacement.length > 0) {
+			if (opts.spaceReplacement) {
 				key = key.replace(/[^\d\p{L}]+/gu, opts.spaceReplacement);
 			}
 
@@ -325,19 +384,18 @@ export class Entity {
 			} else if (isString(type)) {
 				toAdd = value;
 			} else if (value.match(/Q\d+$/) && valueLabel) {
-				const id = value.match(/\d+$/);
-				if (!id) continue;
+				const idMatch = value.match(/(\d+)$/);
+				if (!idMatch) continue;
 				const label = Entity.buildLink(
 					opts.internalLinkPrefix,
 					valueLabel,
-					id[0],
+					idMatch[1],
 				);
 				toAdd = `[[${label}]]`;
 			}
 
 			if (toAdd === null) continue;
 
-			// Deduplicate values per key across merged endpoint results
 			if (ret[key]) {
 				const strVal = String(toAdd);
 				if (!ret[key].some((v) => String(v) === strVal)) {
@@ -349,20 +407,36 @@ export class Entity {
 		}
 	}
 
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Fetch all properties for this entity by querying both endpoints and
+	 * merging the results.
+	 *
+	 * - Blazegraph (`query.wikidata.org`) is queried first; it is the
+	 *   authoritative source for non-scholarly entities.
+	 * - QLever is queried second and fills in statements that are missing from
+	 *   Blazegraph due to the scholarly-article graph split. Results are merged
+	 *   and deduplicated.
+	 */
 	async getProperties(opts: GetPropertiesOptions): Promise<Properties> {
 		const ret: Properties = {};
 
-		// --- 1. Query the standard Wikidata SPARQL endpoint ---
-		const wdQuery = this.buildPropertiesQuery(opts, false);
-		const wdResults = await runSparql(WIKIDATA_SPARQL, wdQuery);
-		this.parseBindings(wdResults, opts, ret);
+		const [wdResults, qlResults] = await Promise.all([
+			runSparql(
+				WIKIDATA_SPARQL,
+				this.buildPropertiesQuery(opts, false),
+			),
+			runSparql(
+				QLEVER_SPARQL,
+				WIKIDATA_PREFIXES + this.buildPropertiesQuery(opts, true),
+				true,
+			),
+		]);
 
-		// --- 2. Always also query QLever (which has the full graph
-		//        including scholarly articles) and merge any extra statements.
-		//        QLever does not support wikibase:label SERVICE, so we use
-		//        rdfs:label instead. ---
-		const qlQuery = WIKIDATA_PREFIXES + this.buildPropertiesQuery(opts, true);
-		const qlResults = await runSparql(QLEVER_SPARQL, qlQuery);
+		this.parseBindings(wdResults, opts, ret);
 		this.parseBindings(qlResults, opts, ret);
 
 		return ret;

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -79,12 +79,35 @@ PREFIX bd: <http://www.bigdata.com/rdf#>
  * "en" is appended as a final fallback when not already present, ensuring
  * labels are never silently dropped when the preferred language is unavailable.
  */
+/**
+ * Languages for use with the wikibase:label SERVICE and FILTER(LANG(...)).
+ * "mul" is stripped because it is not a valid BCP-47 tag and silently matches
+ * nothing in those contexts. "en" is added as a fallback.
+ */
 function parseLangs(language: string): string[] {
 	const langs = language
 		.split(",")
 		.map((l) => l.trim().toLowerCase())
 		.filter((l) => l.length > 0 && l !== "mul");
 
+	if (!langs.includes("en")) langs.push("en");
+	return langs;
+}
+
+/**
+ * Languages for use with QLever rdfs:label FILTER — identical to parseLangs
+ * but retains "mul". Wikidata stores many scholarly article titles and other
+ * language-neutral strings under the "mul" language tag in the raw RDF, so
+ * FILTER(LANG(?label) = "mul") is valid and necessary against QLever.
+ */
+function parseLangsForRdfs(language: string): string[] {
+	const langs = language
+		.split(",")
+		.map((l) => l.trim().toLowerCase())
+		.filter((l) => l.length > 0);
+
+	// Always include mul (language-neutral literals) and en as fallback
+	if (!langs.includes("mul")) langs.push("mul");
 	if (!langs.includes("en")) langs.push("en");
 	return langs;
 }
@@ -222,8 +245,11 @@ export class Entity {
 				const response = await requestUrl(url);
 				const json: SearchResponse = response.json;
 				for (const result of json.search) {
-					if (!allResults.has(result.id)) {
+					if (allResults.has(result.id)) continue;
+					try {
 						allResults.set(result.id, Entity.fromJson(result));
+					} catch (e) {
+						console.warn(`[wikidata-importer] Skipping invalid search result:`, result, e);
 					}
 				}
 			} catch (e) {
@@ -255,7 +281,8 @@ export class Entity {
 		return result;
 	}
 
-	static buildLink(link: string, label: string, id: string): string {
+	static buildLink(link: string, label: string | undefined, id: string): string {
+		label = label ?? "";
 		const sanitisedLabel = Entity.replaceCharacters(
 			label,
 			'*/:#?<>[]"',
@@ -291,15 +318,16 @@ export class Entity {
 		const langs = parseLangs(opts.language);
 		const primaryLang = langs[0];
 
+		const rdfsLangs = parseLangsForRdfs(opts.language);
 		const labelFragment = useRdfsLabel
 			? `
 				OPTIONAL {
 					?property rdfs:label ?propertyLabel .
-					FILTER(${langFilter("?propertyLabel", langs)})
+					FILTER(${langFilter("?propertyLabel", rdfsLangs)})
 				}
 				OPTIONAL {
 					?value rdfs:label ?valueLabel .
-					FILTER(${langFilter("?valueLabel", langs)})
+					FILTER(${langFilter("?valueLabel", rdfsLangs)})
 				}`
 			: `
 				SERVICE wikibase:label {

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -22,6 +22,47 @@ export interface SearchOptions {
 	language: string;
 }
 
+// Wikidata SPARQL endpoint (main graph — excludes scholarly articles post-split)
+const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
+
+// QLever endpoint for Wikidata — full graph including scholarly articles
+// See: https://qlever.cs.uni-freiburg.de/wikidata
+const QLEVER_SPARQL = "https://qlever.cs.uni-freiburg.de/api/wikidata";
+
+// Standard Wikidata prefixes that query.wikidata.org injects automatically
+// but QLever requires explicitly.
+const WIKIDATA_PREFIXES = `
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX wikibase: <http://wikiba.se/ontology#>
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX ps: <http://www.wikidata.org/prop/statement/>
+PREFIX psn: <http://www.wikidata.org/prop/statement/value-normalized/>
+PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
+PREFIX pqn: <http://www.wikidata.org/prop/qualifier/value-normalized/>
+PREFIX pr: <http://www.wikidata.org/prop/reference/>
+PREFIX prn: <http://www.wikidata.org/prop/reference/value-normalized/>
+PREFIX wdref: <http://www.wikidata.org/reference/>
+PREFIX wdv: <http://www.wikidata.org/value/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <http://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX bd: <http://www.bigdata.com/rdf#>
+`;
+
+// Scholarly article instance-of QIDs that live in the split-off graph
+const SCHOLARLY_QIDS = new Set([
+	"Q13442814", // scholarly article
+	"Q191067",   // article
+	"Q17928402", // scientific article
+	"Q18918145", // academic journal article
+	"Q23927052", // conference paper
+	"Q87715823", // preprint
+	"Q580922",   // review article
+]);
+
 function isString(type: string | null): boolean {
 	if (!type) return false;
 	return (
@@ -43,6 +84,51 @@ function isDecimal(type: string | null): boolean {
 function isDate(type: string | null): boolean {
 	if (!type) return false;
 	return type === "http://www.w3.org/2001/XMLSchema#dateTime";
+}
+
+/**
+ * Run a SPARQL SELECT query against the given endpoint and return raw bindings.
+ */
+async function runSparql(
+	endpoint: string,
+	query: string,
+): Promise<any[]> {
+	const url = `${endpoint}?query=${encodeURIComponent(query)}&format=json`;
+	try {
+		const response = await requestUrl({
+			url,
+			headers: {
+				// QLever requires an explicit Accept header for JSON
+				Accept: "application/sparql-results+json",
+			},
+		});
+		return response.json?.results?.bindings ?? [];
+	} catch (e) {
+		console.warn(`SPARQL query failed for endpoint ${endpoint}:`, e);
+		return [];
+	}
+}
+
+/**
+ * Check whether a Wikidata entity is a scholarly article by querying
+ * QLever for its instance-of values.
+ */
+async function isScholarlyEntity(id: string): Promise<boolean> {
+	const query = WIKIDATA_PREFIXES + `
+		SELECT ?type WHERE {
+			wd:${id} wdt:P31 ?type .
+		}
+		LIMIT 20
+	`;
+	const bindings = await runSparql(QLEVER_SPARQL, query);
+	for (const b of bindings) {
+		const typeUrl: string = b.type?.value ?? "";
+		const qid = typeUrl.match(/Q\d+$/)?.[0];
+		if (qid && SCHOLARLY_QIDS.has(`Q${qid.replace(/^Q/, "")}`)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 export class Entity {
@@ -108,18 +194,15 @@ export class Entity {
 		replaceString: string,
 	) {
 		let result = str;
-
 		for (let i = 0; i < searchString.length; i++) {
 			const searchChar = searchString[i];
 			const replaceChar =
 				replaceString[Math.min(i, replaceString.length - 1)];
-
 			result = result.replace(
 				new RegExp(`\\${searchChar}`, "g"),
 				replaceChar,
 			);
 		}
-
 		return result;
 	}
 
@@ -134,8 +217,27 @@ export class Entity {
 			.replace(/\$\{id\}/g, id);
 	}
 
-	// TODO: incorporate https://query.wikidata.org/#SELECT%20%3FwdLabel%20%3Fps_Label%20%3FwdpqLabel%20%3Fpq_Label%20%7B%0A%20%20VALUES%20%28%3Fcompany%29%20%7B%28wd%3AQ5284%29%7D%0A%20%20%0A%20%20%3Fcompany%20%3Fp%20%3Fstatement%20.%0A%20%20%3Fstatement%20%3Fps%20%3Fps_%20.%0A%20%20%0A%20%20%3Fwd%20wikibase%3Aclaim%20%3Fp.%0A%20%20%3Fwd%20wikibase%3AstatementProperty%20%3Fps.%0A%20%20%0A%20%20OPTIONAL%20%7B%0A%20%20%3Fstatement%20%3Fpq%20%3Fpq_%20.%0A%20%20%3Fwdpq%20wikibase%3Aqualifier%20%3Fpq%20.%0A%20%20%7D%0A%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22%20%7D%0A%7D%20ORDER%20BY%20%3Fwd%20%3Fstatement%20%3Fps_
-	async getProperties(opts: GetPropertiesOptions): Promise<Properties> {
+	/**
+	 * Build the SPARQL query body used by both endpoints.
+	 * `serviceBlock` is injected differently per endpoint since QLever
+	 * does not support the wikibase:label SERVICE — labels must be
+	 * fetched via rdfs:label directly.
+	 */
+	private buildPropertiesQuery(
+		opts: GetPropertiesOptions,
+		useRdfsLabel: boolean,
+	): string {
+		const labelFragment = useRdfsLabel
+			? `
+				OPTIONAL { ?property rdfs:label ?propertyLabel . FILTER(LANG(?propertyLabel) = "${opts.language}") }
+				OPTIONAL { ?value rdfs:label ?valueLabel . FILTER(LANG(?valueLabel) = "${opts.language}") }
+			`
+			: `
+				SERVICE wikibase:label {
+					bd:serviceParam wikibase:language "[AUTO_LANGUAGE],${opts.language}" .
+				}
+			`;
+
 		let query = `
 			SELECT ?propertyLabel ?value ?valueLabel ?valueType ?normalizedValue ?description WHERE {
 				wd:${this.id} ?propUrl ?value .
@@ -156,24 +258,28 @@ export class Entity {
 			`;
 		}
 
-		query += `
-				SERVICE wikibase:label {
-					bd:serviceParam wikibase:language "[AUTO_LANGUAGE],${opts.language}" .
-				}
-			}
-		`;
+		query += labelFragment + `}`;
 
-		const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(query)}&format=json`;
+		return query;
+	}
 
-		const response = await requestUrl(url);
-		const json = response.json;
-		const results = json.results.bindings;
-
-		const ret: Properties = {};
-
+	/**
+	 * Parse raw SPARQL bindings into a Properties map, merging into `ret`.
+	 * Existing keys are extended rather than overwritten so results from
+	 * multiple endpoints can be combined cleanly.
+	 */
+	private parseBindings(
+		results: any[],
+		opts: GetPropertiesOptions,
+		ret: Properties,
+	): void {
 		for (const r of results) {
-			let key: string = r.propertyLabel.value;
-			const value: string = r.value.value;
+			let key: string = r.propertyLabel?.value;
+			if (!key) continue;
+
+			const value: string = r.value?.value;
+			if (!value) continue;
+
 			const normalizedValue: string | null = r.normalizedValue
 				? r.normalizedValue.value
 				: null;
@@ -198,7 +304,7 @@ export class Entity {
 				continue;
 			}
 
-			if (opts.ignoreIDs && valueLabel && key.match(/\bID\b/)) {
+			if (opts.ignoreIDs && key.match(/\bID\b/)) {
 				continue;
 			}
 
@@ -220,9 +326,7 @@ export class Entity {
 				toAdd = value;
 			} else if (value.match(/Q\d+$/) && valueLabel) {
 				const id = value.match(/\d+$/);
-				if (!id) {
-					continue;
-				}
+				if (!id) continue;
 				const label = Entity.buildLink(
 					opts.internalLinkPrefix,
 					valueLabel,
@@ -231,16 +335,35 @@ export class Entity {
 				toAdd = `[[${label}]]`;
 			}
 
-			if (toAdd === null) {
-				continue;
-			}
+			if (toAdd === null) continue;
 
+			// Deduplicate values per key across merged endpoint results
 			if (ret[key]) {
-				ret[key].push(toAdd);
+				const strVal = String(toAdd);
+				if (!ret[key].some((v) => String(v) === strVal)) {
+					ret[key].push(toAdd);
+				}
 			} else {
 				ret[key] = [toAdd];
 			}
 		}
+	}
+
+	async getProperties(opts: GetPropertiesOptions): Promise<Properties> {
+		const ret: Properties = {};
+
+		// --- 1. Query the standard Wikidata SPARQL endpoint ---
+		const wdQuery = this.buildPropertiesQuery(opts, false);
+		const wdResults = await runSparql(WIKIDATA_SPARQL, wdQuery);
+		this.parseBindings(wdResults, opts, ret);
+
+		// --- 2. Always also query QLever (which has the full graph
+		//        including scholarly articles) and merge any extra statements.
+		//        QLever does not support wikibase:label SERVICE, so we use
+		//        rdfs:label instead. ---
+		const qlQuery = WIKIDATA_PREFIXES + this.buildPropertiesQuery(opts, true);
+		const qlResults = await runSparql(QLEVER_SPARQL, qlQuery);
+		this.parseBindings(qlResults, opts, ret);
 
 		return ret;
 	}

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -26,21 +26,22 @@ export interface SearchOptions {
 // Endpoints
 // ---------------------------------------------------------------------------
 
-/** Wikidata Blazegraph endpoint. Post graph-split it no longer serves scholarly
- *  articles (instance of Q13442814 and related types). */
+/** Wikidata Blazegraph endpoint. Following the graph split it no longer
+ *  serves scholarly articles (instance of Q13442814 and related types).
+ *  @see https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split */
 const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
 
 /** QLever Wikidata mirror — full graph, including the scholarly-article split.
- *  Does NOT support the wikibase:label SERVICE; uses rdfs:label instead.
- *  Does NOT accept &format=json; format is negotiated via Accept header only. */
+ *  Differences from Blazegraph:
+ *  - Does NOT support the wikibase:label SERVICE; labels fetched via rdfs:label.
+ *  - Does NOT accept &format=json; format negotiated via Accept header only.
+ *  - Requires explicit PREFIX declarations (Blazegraph injects them implicitly). */
 const QLEVER_SPARQL = "https://qlever.cs.uni-freiburg.de/api/wikidata";
 
 // ---------------------------------------------------------------------------
-// Prefixes
+// Prefixes (QLever only — Blazegraph injects these automatically)
 // ---------------------------------------------------------------------------
 
-/** Standard Wikidata SPARQL prefixes. Blazegraph injects these automatically;
- *  QLever requires them to be declared explicitly. */
 const WIKIDATA_PREFIXES = `\
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
@@ -67,13 +68,16 @@ PREFIX bd: <http://www.bigdata.com/rdf#>
 // ---------------------------------------------------------------------------
 
 /**
- * Parse the user-supplied language setting (e.g. "mul,en", "de", "zh,en") into
- * an ordered list of real BCP-47 language tags, dropping the Wikidata-internal
- * pseudo-code "mul" which is not valid inside SPARQL FILTER(LANG(…)) or the
- * wikibase:label SERVICE.
+ * Parse the user-supplied language setting into an ordered list of real BCP-47
+ * language tags.
  *
- * "en" is appended as a final fallback if not already present, so labels are
- * never silently dropped when the preferred language is unavailable.
+ * "mul" is a Wikidata-internal pseudo-code meaning "multiple languages". It is
+ * accepted by the Wikidata action API but is NOT a valid BCP-47 tag and will
+ * silently match nothing inside a SPARQL FILTER(LANG(...)) expression or the
+ * wikibase:label SERVICE. It is therefore stripped here.
+ *
+ * "en" is appended as a final fallback when not already present, ensuring
+ * labels are never silently dropped when the preferred language is unavailable.
  */
 function parseLangs(language: string): string[] {
 	const langs = language
@@ -86,7 +90,7 @@ function parseLangs(language: string): string[] {
 }
 
 /**
- * Build a SPARQL FILTER expression that accepts any of the given language tags.
+ * Build a SPARQL FILTER clause that accepts any of the given language tags:
  *   FILTER(LANG(?x) = "de" || LANG(?x) = "en")
  */
 function langFilter(variable: string, langs: string[]): string {
@@ -94,7 +98,7 @@ function langFilter(variable: string, langs: string[]): string {
 }
 
 // ---------------------------------------------------------------------------
-// Type helpers
+// XSD type helpers
 // ---------------------------------------------------------------------------
 
 function isString(type: string | null): boolean {
@@ -128,10 +132,10 @@ function isDate(type: string | null): boolean {
  * Execute a SPARQL SELECT query and return the raw result bindings.
  *
  * @param endpoint  Full base URL of the SPARQL endpoint.
- * @param query     Complete SPARQL query string (including PREFIX declarations
- *                  when targeting QLever).
+ * @param query     Complete SPARQL query string. Must include PREFIX declarations
+ *                  when targeting QLever (Blazegraph injects them automatically).
  * @param qlever    When true, omits the Blazegraph-specific `&format=json`
- *                  query parameter; format is negotiated via Accept header only.
+ *                  parameter; the response format is negotiated via Accept header.
  */
 async function runSparql(
 	endpoint: string,
@@ -169,28 +173,37 @@ export class Entity {
 		this.description = description;
 	}
 
+	/**
+	 * Construct an Entity from a raw Wikidata API search result.
+	 * `label` and `description` are optional: stub items and newly created
+	 * entities may legitimately lack one or both fields.
+	 */
 	static fromJson(json: any): Entity {
 		if (!json.id || typeof json.id !== "string") {
-			throw new Error("Invalid entity ID");
+			throw new Error("Invalid entity: missing id");
 		}
-		if (!json.label || typeof json.label !== "string") {
-			throw new Error("Invalid entity label");
-		}
-		if (!json.description || typeof json.description !== "string") {
-			throw new Error("Invalid entity description");
-		}
-		return new Entity(json.id, json.label, json.description);
+		return new Entity(
+			json.id,
+			typeof json.label === "string" ? json.label : undefined,
+			typeof json.description === "string" ? json.description : undefined,
+		);
 	}
 
 	static fromId(id: string): Entity {
 		return new Entity(id);
 	}
 
+	/**
+	 * Search Wikidata for entities matching `query`.
+	 *
+	 * The language setting may be a comma-separated list (e.g. "mul,en").
+	 * "mul" is kept here because the Wikidata action API accepts it and uses it
+	 * to return labels in whatever language is available — unlike SPARQL queries
+	 * where "mul" must be stripped (see parseLangs).
+	 */
 	static async search(query: string, opts: SearchOptions): Promise<Entity[]> {
 		if (!query || query.length === 0) return [];
 
-		// Support comma-separated language list, including "mul" which the
-		// Wikidata action API does accept (unlike SPARQL FILTER).
 		const languages = opts.language
 			.split(",")
 			.map((l) => l.trim().toLowerCase())
@@ -254,30 +267,28 @@ export class Entity {
 	}
 
 	// -------------------------------------------------------------------------
-	// Query builders
+	// Query builder
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Build the shared body of the properties SPARQL query.
+	 * Build the SPARQL SELECT query for fetching all properties of this entity.
 	 *
-	 * Two label strategies are supported:
+	 * Two label strategies are supported depending on the target endpoint:
 	 *
-	 * - Blazegraph (`useRdfsLabel = false`): uses the wikibase:label SERVICE
-	 *   which resolves labels server-side and handles language fallback
-	 *   automatically.
+	 * **Blazegraph** (`useRdfsLabel = false`): uses the proprietary
+	 * `wikibase:label SERVICE` which resolves labels server-side with built-in
+	 * language fallback.
 	 *
-	 * - QLever (`useRdfsLabel = true`): the wikibase:label SERVICE is not
-	 *   supported, so labels are fetched via rdfs:label with an explicit
-	 *   FILTER over the user's preferred languages plus "en" as a fallback.
-	 *   "mul" is excluded because it is not a valid BCP-47 tag in FILTER(LANG()).
+	 * **QLever** (`useRdfsLabel = true`): the `wikibase:label SERVICE` is not
+	 * supported, so property and value labels are fetched via `rdfs:label` with
+	 * explicit language filters. The primary language is preferred over the
+	 * fallback via filter ordering.
 	 */
 	private buildPropertiesQuery(
 		opts: GetPropertiesOptions,
 		useRdfsLabel: boolean,
 	): string {
 		const langs = parseLangs(opts.language);
-		// For the description OPTIONAL we use the first real language only
-		// (FILTER supports only one tag here in both endpoints).
 		const primaryLang = langs[0];
 
 		const labelFragment = useRdfsLabel
@@ -303,10 +314,6 @@ export class Entity {
 					wd:${this.id} schema:description ?description .
 					FILTER(LANG(?description) = "${primaryLang}")
 				}
-				OPTIONAL {
-					?statement psn:P31 ?normalizedValue .
-					?normalizedValue wikibase:quantityUnit ?unit .
-				}
 				BIND(DATATYPE(?value) AS ?valueType) .
 		`;
 
@@ -327,10 +334,10 @@ export class Entity {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Translate raw SPARQL result bindings into the Properties map, merging
-	 * into `ret`. Values that already exist (from a previous endpoint) are
-	 * deduplicated by string representation so that running both Blazegraph and
-	 * QLever never produces duplicate frontmatter entries.
+	 * Translate raw SPARQL result bindings into the Properties map, merging into
+	 * `ret`. Values already present from a prior endpoint are deduplicated by
+	 * string representation, so querying both Blazegraph and QLever never
+	 * produces duplicate frontmatter entries.
 	 */
 	private parseBindings(
 		results: any[],
@@ -349,10 +356,7 @@ export class Entity {
 			const type: string | null = r.valueType?.value ?? null;
 			const valueLabel: string | null = r.valueLabel?.value ?? null;
 
-			if (
-				opts.ignoreCategories &&
-				valueLabel?.startsWith("Category:")
-			) {
+			if (opts.ignoreCategories && valueLabel?.startsWith("Category:")) {
 				continue;
 			}
 
@@ -383,15 +387,17 @@ export class Entity {
 				toAdd = Number.parseInt(value);
 			} else if (isString(type)) {
 				toAdd = value;
-			} else if (value.match(/Q\d+$/) && valueLabel) {
-				const idMatch = value.match(/(\d+)$/);
-				if (!idMatch) continue;
-				const label = Entity.buildLink(
-					opts.internalLinkPrefix,
-					valueLabel,
-					idMatch[1],
-				);
-				toAdd = `[[${label}]]`;
+			} else {
+				// Entity-valued property: value URL ends in /Q<digits>
+				const entityMatch = value.match(/\/(Q(\d+))$/);
+				if (entityMatch && valueLabel) {
+					const label = Entity.buildLink(
+						opts.internalLinkPrefix,
+						valueLabel,
+						entityMatch[2], // numeric part only, matching original behaviour
+					);
+					toAdd = `[[${label}]]`;
+				}
 			}
 
 			if (toAdd === null) continue;
@@ -412,14 +418,18 @@ export class Entity {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Fetch all properties for this entity by querying both endpoints and
-	 * merging the results.
+	 * Fetch all properties for this entity and return them as a key->values map.
 	 *
-	 * - Blazegraph (`query.wikidata.org`) is queried first; it is the
-	 *   authoritative source for non-scholarly entities.
-	 * - QLever is queried second and fills in statements that are missing from
-	 *   Blazegraph due to the scholarly-article graph split. Results are merged
-	 *   and deduplicated.
+	 * Both SPARQL endpoints are queried in parallel and their results merged:
+	 *
+	 * - **Blazegraph** (`query.wikidata.org`) — authoritative for the majority
+	 *   of Wikidata entities.
+	 * - **QLever** (`qlever.cs.uni-freiburg.de`) — full Wikidata graph mirror,
+	 *   required for scholarly articles which were moved out of the Blazegraph.
+	 *   @see https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split
+	 *
+	 * Duplicate property values across both responses are deduplicated before
+	 * the result is returned.
 	 */
 	async getProperties(opts: GetPropertiesOptions): Promise<Properties> {
 		const ret: Properties = {};

--- a/src/wikidata.ts
+++ b/src/wikidata.ts
@@ -22,6 +22,13 @@ export interface SearchOptions {
 	language: string;
 }
 
+export class EntityNotFoundError extends Error {
+	constructor(id: string) {
+		super(`Wikidata entity ${id} was not found`);
+		this.name = "EntityNotFoundError";
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Endpoints
 // ---------------------------------------------------------------------------
@@ -31,12 +38,12 @@ export interface SearchOptions {
  *  @see https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split */
 const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
 
-/** QLever Wikidata mirror — full graph, including the scholarly-article split.
+/** QLever Wikidata mirror — third-party full graph, including scholarly items.
  *  Differences from Blazegraph:
  *  - Does NOT support the wikibase:label SERVICE; labels fetched via rdfs:label.
  *  - Does NOT accept &format=json; format negotiated via Accept header only.
  *  - Requires explicit PREFIX declarations (Blazegraph injects them implicitly). */
-const QLEVER_SPARQL = "https://qlever.cs.uni-freiburg.de/api/wikidata";
+const QLEVER_SPARQL = "https://qlever.dev/api/wikidata";
 
 // ---------------------------------------------------------------------------
 // Prefixes (QLever only — Blazegraph injects these automatically)
@@ -68,18 +75,6 @@ PREFIX bd: <http://www.bigdata.com/rdf#>
 // ---------------------------------------------------------------------------
 
 /**
- * Parse the user-supplied language setting into an ordered list of real BCP-47
- * language tags.
- *
- * "mul" is a Wikidata-internal pseudo-code meaning "multiple languages". It is
- * accepted by the Wikidata action API but is NOT a valid BCP-47 tag and will
- * silently match nothing inside a SPARQL FILTER(LANG(...)) expression or the
- * wikibase:label SERVICE. It is therefore stripped here.
- *
- * "en" is appended as a final fallback when not already present, ensuring
- * labels are never silently dropped when the preferred language is unavailable.
- */
-/**
  * Languages for use with the wikibase:label SERVICE and FILTER(LANG(...)).
  * "mul" is stripped because it is not a valid BCP-47 tag and silently matches
  * nothing in those contexts. "en" is added as a fallback.
@@ -95,10 +90,9 @@ function parseLangs(language: string): string[] {
 }
 
 /**
- * Languages for use with QLever rdfs:label FILTER — identical to parseLangs
- * but retains "mul". Wikidata stores many scholarly article titles and other
- * language-neutral strings under the "mul" language tag in the raw RDF, so
- * FILTER(LANG(?label) = "mul") is valid and necessary against QLever.
+ * Languages for use with QLever rdfs:label fallback. This retains "mul"
+ * because Wikidata stores many scholarly article titles and other
+ * language-neutral strings under that tag in the raw RDF.
  */
 function parseLangsForRdfs(language: string): string[] {
 	const langs = language
@@ -113,11 +107,27 @@ function parseLangsForRdfs(language: string): string[] {
 }
 
 /**
- * Build a SPARQL FILTER clause that accepts any of the given language tags:
- *   FILTER(LANG(?x) = "de" || LANG(?x) = "en")
+ * Build SPARQL that binds exactly one label using the configured language
+ * order. This avoids QLever returning one result row per matching language.
  */
-function langFilter(variable: string, langs: string[]): string {
-	return langs.map((l) => `LANG(${variable}) = "${l}"`).join(" || ");
+function preferredRdfsLabel(
+	entityVariable: string,
+	labelVariable: string,
+	langs: string[],
+): string {
+	const labelCandidates = langs.map((_, i) => `${labelVariable}${i}`);
+	const optionalLabels = langs
+		.map(
+			(lang, i) => `
+				OPTIONAL {
+					${entityVariable} rdfs:label ${labelCandidates[i]} .
+					FILTER(LANG(${labelCandidates[i]}) = "${lang}")
+				}`,
+		)
+		.join("");
+
+	return `${optionalLabels}
+				BIND(COALESCE(${labelCandidates.join(", ")}) AS ${labelVariable})`;
 }
 
 // ---------------------------------------------------------------------------
@@ -169,16 +179,15 @@ async function runSparql(
 		? `${endpoint}?query=${encodeURIComponent(query)}`
 		: `${endpoint}?query=${encodeURIComponent(query)}&format=json`;
 
-	try {
-		const response = await requestUrl({
-			url,
-			headers: { Accept: "application/sparql-results+json" },
-		});
-		return response.json?.results?.bindings ?? [];
-	} catch (e) {
-		console.warn(`[wikidata-importer] SPARQL query failed (${endpoint}):`, e);
-		return [];
+	const response = await requestUrl({
+		url,
+		headers: { Accept: "application/sparql-results+json" },
+	});
+	const bindings = response.json?.results?.bindings;
+	if (!Array.isArray(bindings)) {
+		throw new Error(`Invalid SPARQL response from ${endpoint}`);
 	}
+	return bindings;
 }
 
 // ---------------------------------------------------------------------------
@@ -249,7 +258,11 @@ export class Entity {
 					try {
 						allResults.set(result.id, Entity.fromJson(result));
 					} catch (e) {
-						console.warn(`[wikidata-importer] Skipping invalid search result:`, result, e);
+						console.warn(
+							`[wikidata-importer] Skipping invalid search result:`,
+							result,
+							e,
+						);
 					}
 				}
 			} catch (e) {
@@ -281,7 +294,11 @@ export class Entity {
 		return result;
 	}
 
-	static buildLink(link: string, label: string | undefined, id: string): string {
+	static buildLink(
+		link: string,
+		label: string | undefined,
+		id: string,
+	): string {
 		label = label ?? "";
 		const sanitisedLabel = Entity.replaceCharacters(
 			label,
@@ -321,14 +338,8 @@ export class Entity {
 		const rdfsLangs = parseLangsForRdfs(opts.language);
 		const labelFragment = useRdfsLabel
 			? `
-				OPTIONAL {
-					?property rdfs:label ?propertyLabel .
-					FILTER(${langFilter("?propertyLabel", rdfsLangs)})
-				}
-				OPTIONAL {
-					?value rdfs:label ?valueLabel .
-					FILTER(${langFilter("?valueLabel", rdfsLangs)})
-				}`
+				${preferredRdfsLabel("?property", "?propertyLabel", langs)}
+				${preferredRdfsLabel("?value", "?valueLabel", rdfsLangs)}`
 			: `
 				SERVICE wikibase:label {
 					bd:serviceParam wikibase:language "${langs.join(",")}" .
@@ -353,7 +364,7 @@ export class Entity {
 			`;
 		}
 
-		query += labelFragment + "\n\t\t}";
+		query += `${labelFragment}\n\t\t}`;
 		return query;
 	}
 
@@ -452,8 +463,8 @@ export class Entity {
 	 *
 	 * - **Blazegraph** (`query.wikidata.org`) — authoritative for the majority
 	 *   of Wikidata entities.
-	 * - **QLever** (`qlever.cs.uni-freiburg.de`) — full Wikidata graph mirror,
-	 *   required for scholarly articles which were moved out of the Blazegraph.
+	 * - **QLever** (`qlever.dev`) — third-party full Wikidata graph mirror,
+	 *   used for scholarly articles which were moved out of the main graph.
 	 *   @see https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split
 	 *
 	 * Duplicate property values across both responses are deduplicated before
@@ -463,16 +474,17 @@ export class Entity {
 		const ret: Properties = {};
 
 		const [wdResults, qlResults] = await Promise.all([
-			runSparql(
-				WIKIDATA_SPARQL,
-				this.buildPropertiesQuery(opts, false),
-			),
+			runSparql(WIKIDATA_SPARQL, this.buildPropertiesQuery(opts, false)),
 			runSparql(
 				QLEVER_SPARQL,
 				WIKIDATA_PREFIXES + this.buildPropertiesQuery(opts, true),
 				true,
 			),
 		]);
+
+		if (wdResults.length === 0 && qlResults.length === 0) {
+			throw new EntityNotFoundError(this.id);
+		}
 
 		this.parseBindings(wdResults, opts, ret);
 		this.parseBindings(qlResults, opts, ret);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"exclude": ["**/*.test.ts", "**/test-setup.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
 	"compilerOptions": {
-		"baseUrl": ".",
 		"inlineSourceMap": true,
 		"inlineSources": true,
-		"module": "ESNext",
+		"module": "Node16",
 		"target": "ES6",
 		"allowJs": true,
 		"noImplicitAny": true,
-		"moduleResolution": "node",
+		"moduleResolution": "node16",
 		"importHelpers": true,
 		"isolatedModules": true,
 		"strictNullChecks": true,
+		"types": ["node", "bun-types"],
 		"lib": ["DOM", "ES5", "ES6", "ES7"]
 	},
 	"include": ["**/*.ts"]


### PR DESCRIPTION
Hi @samwho,

I really love your plugin!
Recently I wanted to import some scholarly articles from Wikidata, but the imported notes were coming out empty due to the recent [WDQS graph split](https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split).
This PR fixes that by querying both the official WDQS endpoint and [QLever](https://qlever.cs.uni-freiburg.de/wikidata) in parallel, then merging the results.
Non-scholarly entities are unaffected, scholarly articles now get fully populated from QLever.